### PR TITLE
Number of new requests (updates) for a user

### DIFF
--- a/server/src/offer/offer.controller.ts
+++ b/server/src/offer/offer.controller.ts
@@ -163,6 +163,17 @@ export class OfferController {
 	}
 
 	/**
+	 * returns a number of new open requests fo a user
+	 * @param reqBody session object
+	 */
+	@Post('get-number-of-new-offer-requests')
+	getNumberOfNewOfferRequestsPerUser(
+		@Body() reqBody: {}
+	) {
+		return this.offerService.getNumberOfNewOfferRequestsPerUser(reqBody);
+	}
+
+	/**
 	 * Books offer for a specified time frame, given sufficient authorization.
 	 * @param id ID of offer to be booked
 	 * @param reqBody body of the request is used for passing authorization details

--- a/server/src/offer/offer.controller.ts
+++ b/server/src/offer/offer.controller.ts
@@ -163,7 +163,9 @@ export class OfferController {
 	}
 
 	/**
-	 * returns a number of new open requests fo a user
+	 * Returns the number of new opened offer requests for lessor view
+	 * and the number of accepted / rejected updates for lessee view
+	 * and the total number of updates (sum of all)
 	 * @param reqBody session object
 	 */
 	@Post('get-number-of-new-offer-requests')

--- a/server/src/offer/offer.service.ts
+++ b/server/src/offer/offer.service.ts
@@ -1344,6 +1344,13 @@ export class OfferService {
 						throw new InternalServerErrorException("Something went wrong");
 					}
 
+					// Check if lessor / lesse did not sent request
+					// => Other people who are not lessor / lesse should not see requests!
+					if(dbRequests[0].user_id !== userResponse.user.user_id
+						&& offer.lessor.user_id !== userResponse.user.user_id) {
+						throw new UnauthorizedException("Unauthorized to see this request");
+					}
+
 					// Lessee sent request and status code matches OR lessor sent request and status code matches
 					if (
 						(dbRequests[0].user_id === userResponse.user.user_id &&
@@ -1775,7 +1782,9 @@ export class OfferService {
 	}
 
 	/**
-	 * Returns the number of new opened offer requests
+	 * Returns the number of new opened offer requests for lessor view
+	 * and the number of accepted / rejected updates for lessee view
+	 * and the total number of updates (sum of all)
 	 * @param reqBody Uses a session object to get all request numbers per user
 	 */
 	public async getNumberOfNewOfferRequestsPerUser(reqBody: {
@@ -1784,14 +1793,15 @@ export class OfferService {
 			user_id?: string
 		}
 	}): Promise<{
-		number_of_new_requests: number
-		// number_of_new_accepted_requests: number,
-		// number_of_new_rejected_requests: number
+		number_of_new_requests: number,
+		number_of_new_accepted_requests: number,
+		number_of_new_rejected_requests: number,
+		total_number_of_updates: number
 	}> {
 		if (!reqBody || !reqBody.session) {
 			throw new BadRequestException("Not a valid request");
 		}
-
+		
 		let userResponse = await this.userService.validateUser({
 			session: {
 				session_id: reqBody.session.session_id,
@@ -1805,26 +1815,29 @@ export class OfferService {
 		}
 
 		// Get number of requests per state
+		// If REQUEST_STATUS_OPEN is set in query the number of open requests
+		// is calculated by using the userId from offer of request
+		// If request is accepted / rejected the userId from request is used
 		let numberOfNewRequests = ((await Connector.executeQuery(
 			QueryBuilder.getNumberOfNewOfferRequestsPerUser(
 				reqBody.session.user_id,
 				StaticConsts.REQUEST_STATUS_OPEN)))[0]).number_of_new_requests;
 
-		// let numberOfNewAcceptedRequests = await Connector.executeQuery(
-		// 	QueryBuilder.getNumberOfNewOfferRequestsPerUser(
-		// 		reqBody.session.user_id,
-		// 		StaticConsts.REQUEST_STATUS_ACCEPTED_BY_LESSOR))[0];
+		let numberOfNewAcceptedRequests = ((await Connector.executeQuery(
+			QueryBuilder.getNumberOfNewOfferRequestsPerUser(
+				reqBody.session.user_id,
+				StaticConsts.REQUEST_STATUS_ACCEPTED_BY_LESSOR)))[0]).number_of_new_requests;
 
-		// let numberOfNewRejectedRequests = await Connector.executeQuery(
-		// 	QueryBuilder.getNumberOfNewOfferRequestsPerUser(
-		// 		reqBody.session.user_id,
-		// 		StaticConsts.REQUEST_STATUS_REJECTED_BY_LESSOR)
-		// );
+		let numberOfNewRejectedRequests = ((await Connector.executeQuery(
+			QueryBuilder.getNumberOfNewOfferRequestsPerUser(
+				reqBody.session.user_id,
+				StaticConsts.REQUEST_STATUS_REJECTED_BY_LESSOR)))[0]).number_of_new_requests;
 
 		let o = {
-			number_of_new_requests: numberOfNewRequests
-			// number_of_new_accepted_requests: numberOfNewAcceptedRequests,
-			// number_of_new_rejected_requests: numberOfNewRejectedRequests
+			number_of_new_requests: numberOfNewRequests,
+			number_of_new_accepted_requests: numberOfNewAcceptedRequests,
+			number_of_new_rejected_requests: numberOfNewRejectedRequests,
+			total_number_of_updates: (numberOfNewRequests + numberOfNewAcceptedRequests + numberOfNewRejectedRequests)
 		}
 		return o;
 	}

--- a/server/src/util/database/query-builder.ts
+++ b/server/src/util/database/query-builder.ts
@@ -387,7 +387,7 @@ export class QueryBuilder {
 					query += " AND offer.price <= ? ";
 					args.push(offer_info.query.price_below);
 				}
-				
+
 				if (offer_info.query.rating_above && offer_info.query.rating_above > StaticConsts.CHECK_ZERO) {
 					query += " AND offer.rating >= ? ";
 					args.push(offer_info.query.rating_above);
@@ -407,36 +407,36 @@ export class QueryBuilder {
 					args: args
 				}
 			} else {
-					return {
-						query: `SELECT offer_id, offer.user_id, title, description, rating, price, offer.category_id, category.name AS category_name, category.picture_link, number_of_ratings FROM offer JOIN category ON offer.category_id = category.category_id JOIN user ON offer.user_id = user.user_id WHERE ${offer_info.query.place_ids} AND offer.status_id != ${StaticConsts.OFFER_STATUS_DELETED} LIMIT ?;`,
-						args: [
-							offer_info.query.limit
-						]
-					}
-				}
-			} else if (offer_info.user_id) {
 				return {
-					query: `SELECT offer_id, user_id, title, description, rating, price, offer.category_id, category.name AS category_name, category.picture_link, number_of_ratings FROM offer JOIN category ON offer.category_id = category.category_id WHERE user_id = ? AND offer.status_id != ${StaticConsts.OFFER_STATUS_DELETED};`,
+					query: `SELECT offer_id, offer.user_id, title, description, rating, price, offer.category_id, category.name AS category_name, category.picture_link, number_of_ratings FROM offer JOIN category ON offer.category_id = category.category_id JOIN user ON offer.user_id = user.user_id WHERE ${offer_info.query.place_ids} AND offer.status_id != ${StaticConsts.OFFER_STATUS_DELETED} LIMIT ?;`,
 					args: [
-						offer_info.user_id
+						offer_info.query.limit
 					]
 				}
-			} else {
-				return {
-					query: `SELECT offer_id, user_id, title, description, rating, price, offer.category_id, category.name AS category_name, category.picture_link, number_of_ratings FROM offer JOIN category ON offer.category_id = category.category_id AND offer.status_id != ${StaticConsts.OFFER_STATUS_DELETED} LIMIT ${StaticConsts.LIMIT_FOR_OFFERS_15};`,
-					args: []
-				}
+			}
+		} else if (offer_info.user_id) {
+			return {
+				query: `SELECT offer_id, user_id, title, description, rating, price, offer.category_id, category.name AS category_name, category.picture_link, number_of_ratings FROM offer JOIN category ON offer.category_id = category.category_id WHERE user_id = ? AND offer.status_id != ${StaticConsts.OFFER_STATUS_DELETED};`,
+				args: [
+					offer_info.user_id
+				]
+			}
+		} else {
+			return {
+				query: `SELECT offer_id, user_id, title, description, rating, price, offer.category_id, category.name AS category_name, category.picture_link, number_of_ratings FROM offer JOIN category ON offer.category_id = category.category_id AND offer.status_id != ${StaticConsts.OFFER_STATUS_DELETED} LIMIT ${StaticConsts.LIMIT_FOR_OFFERS_15};`,
+				args: []
 			}
 		}
+	}
 
 	/**
 	 * Returns a list of locations where the distance is in range from a given location
 	 * @param location_info 
 	 */
 	public static getLocationIdsByDistance(location_info: {
-			place_id_1: number,
-			distance: number
-		}): Query {
+		place_id_1: number,
+		distance: number
+	}): Query {
 		return {
 			query: "SELECT place_id_2 FROM distance_matrix WHERE place_id_1 = ? AND distance <= ?",
 			args: [
@@ -1001,10 +1001,42 @@ export class QueryBuilder {
 		}
 	}
 
+	/**
+	 * Used to close offers after a timeout happens
+	 */
 	public static closeTimedOutOffers() {
 		return {
 			query: `UPDATE request SET status_id = ${StaticConsts.REQUEST_STATUS_REQUEST_TIMED_OUT} WHERE status_id = ${StaticConsts.OFFER_STATUS_DELETED} AND NOW() > from_date;`,
 			args: []
+		}
+	}
+
+	/**
+	 * Updates the timestamp when a user made a request to get a request object
+	 * @param requestId Id of the request to be updated
+	 */
+	public static updateLastUpdateRequestTimestamp(requestId: string) {
+		return {
+			query: "UPDATE request SET last_update_request_from_user = NOW() WHERE request.request_id = ?;",
+			args: [
+				requestId
+			]
+		}
+	}
+
+	/**
+	 * Returns the number of requests with a created timestamp greater than the last update
+	 * for a given status and user
+	 * @param userId Id of user to get request numbers for
+	 * @param requestState State of the request for filtering
+	 */
+	public static getNumberOfNewOfferRequestsPerUser(userId: string, requestState: number) {
+		return {
+			query: "SELECT COUNT(request.request_id) as number_of_new_requests FROM request WHERE request.status_id = ? AND request.user_id = ? AND request.created_on >= request.last_update_request_from_user; ",
+			args: [
+				requestState,
+				userId
+			]
 		}
 	}
 

--- a/server/src/util/database/query-builder.ts
+++ b/server/src/util/database/query-builder.ts
@@ -824,7 +824,7 @@ export class QueryBuilder {
 						args: [
 							request_info.user_id,
 							request_info.status_code,
-							3
+							StaticConsts.REQUEST_STATUS_REJECTED_BY_LESSOR
 						]
 					}
 				} else {
@@ -833,7 +833,7 @@ export class QueryBuilder {
 						args: [
 							request_info.user_id,
 							request_info.status_code,
-							3
+							StaticConsts.REQUEST_STATUS_REJECTED_BY_LESSOR
 						]
 					}
 				}


### PR DESCRIPTION
The Endpoint ```/offer/get-number-of-new-offer-requests``` returns the number of updates for a user in lessor and lessee view:
Number_of_new_requests is for open requests from lessors view,
number of accepted / rejected requests is for lessees view:

```POST```-Body:
```javascript
session?: {
	session_id?: string,
	user_id?: string
}
```

Returned from Endpoint
```javascript
number_of_new_requests: number,
number_of_new_accepted_requests: number,
number_of_new_rejected_requests: number,
total_number_of_updates: number
```